### PR TITLE
Feat/#57/ 백과사전 Ux개선 및 애널리틱스 이벤트 추가

### DIFF
--- a/lawding_flutter/lib/infrastructure/services/analytics_service.dart
+++ b/lawding_flutter/lib/infrastructure/services/analytics_service.dart
@@ -238,6 +238,14 @@ class AnalyticsService {
     await _analytics.logEvent(name: 'app_launched');
   }
 
+  // 인앱 리뷰 요청 노출 이벤트
+  Future<void> logInAppReviewRequested({required String trigger}) async {
+    await _analytics.logEvent(
+      name: 'in_app_review_requested',
+      parameters: {'trigger': trigger},
+    );
+  }
+
   // 스플래시 화면 완료 이벤트
   Future<void> logSplashCompleted(int durationMs) async {
     await _analytics.logEvent(

--- a/lawding_flutter/lib/infrastructure/services/in_app_review_service.dart
+++ b/lawding_flutter/lib/infrastructure/services/in_app_review_service.dart
@@ -1,6 +1,8 @@
 import 'package:in_app_review/in_app_review.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'analytics_service.dart';
+
 class InAppReviewService {
   static final InAppReviewService _instance = InAppReviewService._internal();
   factory InAppReviewService() => _instance;
@@ -17,7 +19,7 @@ class InAppReviewService {
 
   /// 계산 결과 화면 '처음으로' 버튼 클릭 시 호출
   Future<void> onResultScreenHome() async {
-    await _requestReviewIfEligible();
+    await _requestReviewIfEligible(trigger: 'result_screen');
   }
 
   /// 용어사전 아이템 펼치기 시 호출 — 누적 3회 달성 시 리뷰 요청
@@ -27,17 +29,18 @@ class InAppReviewService {
     await prefs.setInt(_keyDictionaryExpandCount, count);
 
     if (count >= _expandThreshold) {
-      await _requestReviewIfEligible();
+      await _requestReviewIfEligible(trigger: 'dictionary_expand');
     }
   }
 
   /// 쿨다운 조건 확인 후 리뷰 요청
-  Future<void> _requestReviewIfEligible() async {
+  Future<void> _requestReviewIfEligible({required String trigger}) async {
     if (!await _isEligible()) return;
 
     final inAppReview = InAppReview.instance;
     if (!await inAppReview.isAvailable()) return;
 
+    await AnalyticsService().logInAppReviewRequested(trigger: trigger);
     await inAppReview.requestReview();
     await _recordRequest();
   }

--- a/lawding_flutter/lib/presentation/screens/dictionary/dictionary_screen.dart
+++ b/lawding_flutter/lib/presentation/screens/dictionary/dictionary_screen.dart
@@ -38,6 +38,9 @@ class _DictionaryScreenState extends ConsumerState<DictionaryScreen>
   // 최초 접근 체크 완료 여부
   bool _hasCheckedFirstAccess = false;
 
+  // 각 아이템의 위치를 추적하기 위한 GlobalKey 맵
+  final Map<int, GlobalKey> _itemKeys = {};
+
   @override
   void initState() {
     super.initState();
@@ -434,13 +437,19 @@ class _DictionaryScreenState extends ConsumerState<DictionaryScreen>
       itemBuilder: (context, index) {
         final dictionary = state.filteredDictionaries[index];
         final isExpanded = state.expandedIds.contains(dictionary.id);
-        return _buildDictionaryItem(dictionary, isExpanded);
+        final itemKey = _itemKeys[dictionary.id] ??= GlobalKey();
+        return _buildDictionaryItem(dictionary, isExpanded, itemKey);
       },
     );
   }
 
-  Widget _buildDictionaryItem(Dictionary dictionary, bool isExpanded) {
+  Widget _buildDictionaryItem(
+    Dictionary dictionary,
+    bool isExpanded,
+    GlobalKey itemKey,
+  ) {
     return Container(
+      key: itemKey,
       margin: const EdgeInsets.only(bottom: 14),
       decoration: BoxDecoration(
         color: Colors.white,
@@ -462,8 +471,18 @@ class _DictionaryScreenState extends ConsumerState<DictionaryScreen>
               .read(dictionaryViewModelProvider.notifier)
               .toggleExpanded(dictionary.id);
 
-          // 펼치기/접기 이벤트 기록
           if (willBeExpanded) {
+            // 펼치기 애니메이션과 동시에 스크롤 → 하나의 자연스러운 동작처럼 보임
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (!mounted || itemKey.currentContext == null) return;
+              Scrollable.ensureVisible(
+                itemKey.currentContext!,
+                alignment: 0.0,
+                duration: const Duration(milliseconds: 250),
+                curve: Curves.fastOutSlowIn,
+              );
+            });
+
             _analytics.logDictionaryItemExpanded(
               dictionaryId: dictionary.id,
               question: dictionary.question,

--- a/lawding_flutter/lib/presentation/screens/dictionary/dictionary_screen.dart
+++ b/lawding_flutter/lib/presentation/screens/dictionary/dictionary_screen.dart
@@ -718,7 +718,7 @@ class _DictionaryScreenState extends ConsumerState<DictionaryScreen>
                                   '추가했으면 하는 연차 정보를 제안해 주세요',
                                   style: pretendard(
                                     weight: 700,
-                                    size: 16,
+                                    size: 14,
                                     color: AppColors.brandColor,
                                   ),
                                 ),

--- a/lawding_flutter/lib/presentation/screens/dictionary/dictionary_suggestion_screen.dart
+++ b/lawding_flutter/lib/presentation/screens/dictionary/dictionary_suggestion_screen.dart
@@ -55,7 +55,7 @@ class _DictionarySuggestionScreenState
     final state = ref.watch(dictionarySuggestionViewModelProvider);
 
     return CustomScaffold(
-      appBar: const CustomAppBar(title: '질문'),
+      appBar: const CustomAppBar(title: '건의하기'),
       body: SafeArea(
         top: false,
         child: SingleChildScrollView(
@@ -159,16 +159,7 @@ class _DictionarySuggestionScreenState
                   ],
                 ),
               ),
-              const SizedBox(height: 16),
-              Text(
-                '여러분이 추가하면 좋을 내용을 보내주시면 검토할게요',
-                style: pretendard(
-                  weight: 500,
-                  size: 12,
-                  color: AppColors.textGray99,
-                ),
-              ),
-              const SizedBox(height: 22),
+              const SizedBox(height: 26),
               SubmitButton(
                 text: '보내기',
                 isLoading: state.isLoading,

--- a/lawding_flutter/pubspec.yaml
+++ b/lawding_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.3.6+12
+version: 1.3.7+13
 
 environment:
   sdk: ^3.10.1


### PR DESCRIPTION
## 이슈 번호: #57

## PR 타입
- [x] 기능 구현
- [ ] 오류 수정
- [x] 리팩토링

<br>

### 작업 내용
> 백과사전 UX 개선 및 인앱 리뷰 애널리틱스를 추가합니다.

- [x] 백과사전 항목 펼칠 때 해당 아이템 위치로 자동 스크롤 (`Scrollable.ensureVisible` + `GlobalKey`)
- [x] 백과사전 건의하기 화면 UI 수정 (앱바 타이틀, 레이아웃 조정)
- [x] 폰트 스타일 수정
- [x] 인앱 리뷰 팝업 호출 시 `in_app_review_requested` Analytics 이벤트 기록
- [x] 버전 bump (`1.3.7+13`)

<br>

### PR 체크리스트
- [x] PR 제목과 태그 (Feat, Refactor, Fix...etc) 와 작업 내용 확인
- [x] 코딩 컨벤션 확인
- [x] PR 관련 내용만 작성했는가 확인

<br>

### PR 유의 및 기타 사항
> 리뷰 시 주의 깊게 보거나 유의해야 할 점들을 작성합니다.

- 자동 스크롤은 `addPostFrameCallback` 내에서 `Scrollable.ensureVisible`을 호출합니다. 펼치기 애니메이션(250ms)과 동시에 실행되어 자연스럽게 보이도록 의도된 동작입니다.