### PR TITLE
Refactor/#75/캘린더 주요 변경사항 적용

### DIFF
--- a/lawding_flutter/lib/data/calendar_event/calendar_event_mapper.dart
+++ b/lawding_flutter/lib/data/calendar_event/calendar_event_mapper.dart
@@ -19,10 +19,12 @@ extension CalendarEventItemResponseMapper on CalendarEventItemResponse {
 
 /// CalendarEventListApiResponse → `List<CalendarEventEntity>` 변환
 extension CalendarEventListApiResponseMapper on CalendarEventListApiResponse {
-  List<CalendarEventEntity> toDomain() => data.map((item) => item.toDomain()).toList();
+  List<CalendarEventEntity> toDomain() =>
+      data.map((item) => item.toDomain()).toList();
 }
 
 /// CalendarEventSingleApiResponse → CalendarEventEntity 변환
-extension CalendarEventSingleApiResponseMapper on CalendarEventSingleApiResponse {
-  CalendarEventEntity toDomain() => data.toDomain();
+extension CalendarEventSingleApiResponseMapper
+    on CalendarEventSingleApiResponse {
+  CalendarEventEntity toDomain() => data!.toDomain();
 }

--- a/lawding_flutter/lib/data/calendar_event/calendar_event_repository_impl.dart
+++ b/lawding_flutter/lib/data/calendar_event/calendar_event_repository_impl.dart
@@ -42,6 +42,9 @@ class CalendarEventRepositoryImpl implements CalendarEventRepository {
       final apiResponse = CalendarEventSingleApiResponse.fromJson(
         response.data as Map<String, dynamic>,
       );
+      if (apiResponse.data == null) {
+        return const Failure(ServerError(message: '잘못된 응답 형식입니다.'));
+      }
       return Success(apiResponse.toDomain());
     } on NetworkError catch (error) {
       return Failure(error);
@@ -63,18 +66,15 @@ class CalendarEventRepositoryImpl implements CalendarEventRepository {
   }
 
   @override
-  Future<Result<CalendarEventEntity, NetworkError>> updateCalendarEvent({
+  Future<Result<void, NetworkError>> updateCalendarEvent({
     required int id,
     required CalendarEventRequest request,
   }) async {
     try {
-      final response = await _client.request(
+      await _client.request(
         CalendarEventApi.updateCalendarEvent(id: id, request: request),
       );
-      final apiResponse = CalendarEventSingleApiResponse.fromJson(
-        response.data as Map<String, dynamic>,
-      );
-      return Success(apiResponse.toDomain());
+      return const Success(null);
     } on NetworkError catch (error) {
       return Failure(error);
     }

--- a/lawding_flutter/lib/data/calendar_event/calendar_event_response.dart
+++ b/lawding_flutter/lib/data/calendar_event/calendar_event_response.dart
@@ -34,23 +34,24 @@ class CalendarEventListApiResponse {
 class CalendarEventSingleApiResponse {
   final String status;
   final String message;
-  final CalendarEventItemResponse data;
+  final CalendarEventItemResponse? data; // POST/PUT 시 null일 수 있음
   final String timestamp;
 
   const CalendarEventSingleApiResponse({
     required this.status,
     required this.message,
-    required this.data,
+    this.data,
     required this.timestamp,
   });
 
   factory CalendarEventSingleApiResponse.fromJson(Map<String, dynamic> json) {
+    final rawData = json['data'];
     return CalendarEventSingleApiResponse(
       status: json['status'] as String,
       message: json['message'] as String,
-      data: CalendarEventItemResponse.fromJson(
-        json['data'] as Map<String, dynamic>,
-      ),
+      data: rawData is Map<String, dynamic>
+          ? CalendarEventItemResponse.fromJson(rawData)
+          : null,
       timestamp: json['timestamp'] as String,
     );
   }

--- a/lawding_flutter/lib/data/network/dio_client.dart
+++ b/lawding_flutter/lib/data/network/dio_client.dart
@@ -18,6 +18,7 @@ class DioClient {
     AuthRepository? authRepository,
     bool isTestMode = kDebugMode,
     Dio? dio,
+    Dio? reissueDio, // 테스트 시 주입 가능
   }) : _dio =
            dio ??
            Dio(
@@ -42,7 +43,9 @@ class DioClient {
     }
 
     if (authRepository != null) {
-      _dio.interceptors.add(_AuthInterceptor(_dio, authRepository));
+      _dio.interceptors.add(
+        _AuthInterceptor(_dio, authRepository, reissueDio: reissueDio),
+      );
     }
   }
 
@@ -143,8 +146,22 @@ class DioClient {
 class _AuthInterceptor extends Interceptor {
   final Dio _dio;
   final AuthRepository _authRepository;
+  // reissue 전용 Dio — 인터셉터 없이 직접 호출해 무한루프 방지
+  late final Dio _reissueDio;
 
-  _AuthInterceptor(this._dio, this._authRepository);
+  _AuthInterceptor(this._dio, this._authRepository, {Dio? reissueDio})
+      : _reissueDio = reissueDio ??
+            Dio(
+              BaseOptions(
+                baseUrl: _dio.options.baseUrl,
+                connectTimeout: const Duration(seconds: 30),
+                receiveTimeout: const Duration(seconds: 30),
+                headers: {
+                  'Content-Type': 'application/json',
+                  'Accept': 'application/json',
+                },
+              ),
+            );
 
   /// 모든 요청에 accessToken 주입
   @override
@@ -171,13 +188,6 @@ class _AuthInterceptor extends Interceptor {
 
     debugPrint('[Auth] 401 감지 → path: ${err.requestOptions.path}');
 
-    // reissue 요청 자체가 401을 반환한 경우: 무한 재시도 방지
-    if (err.requestOptions.path == ApiEndpoints.reissue) {
-      debugPrint('[Auth] reissue 자체 401 → 무한재시도 방지, 토큰 삭제 → 로그아웃');
-      await _authRepository.clearTokens();
-      return handler.next(err);
-    }
-
     final refreshToken = await _authRepository.getRefreshToken();
     if (refreshToken == null) {
       debugPrint('[Auth] refreshToken 없음 → 토큰 삭제 → 로그아웃');
@@ -188,14 +198,20 @@ class _AuthInterceptor extends Interceptor {
     debugPrint('[Auth] refreshToken 존재 → reissue 시도');
 
     try {
-      final response = await _dio.post(
+      // 인터셉터 없는 별도 Dio로 reissue 호출 → 무한루프 방지
+      final response = await _reissueDio.post(
         ApiEndpoints.reissue,
         data: {'refreshToken': refreshToken},
-        options: Options(headers: {'Authorization': null}),
       );
 
-      final newAccessToken = response.data['accessToken'] as String;
-      final newRefreshToken = response.data['refreshToken'] as String;
+      final body = response.data;
+      // 응답 구조: { data: { accessToken, refreshToken } } 또는 flat
+      final payload = body is Map && body['data'] is Map
+          ? body['data'] as Map
+          : body as Map;
+
+      final newAccessToken = payload['accessToken'] as String;
+      final newRefreshToken = payload['refreshToken'] as String;
 
       await _authRepository.saveTokens(
         accessToken: newAccessToken,
@@ -211,7 +227,6 @@ class _AuthInterceptor extends Interceptor {
     } on DioException catch (e) {
       final status = e.response?.statusCode;
       if (status == 401 || status == 403) {
-        // refreshToken 만료 → 강제 로그아웃
         debugPrint('[Auth] reissue $status → refreshToken 만료 → 토큰 삭제 → 로그아웃');
         await _authRepository.clearTokens();
       } else {
@@ -220,7 +235,6 @@ class _AuthInterceptor extends Interceptor {
       }
       return handler.next(err);
     } catch (e) {
-      // 파싱 에러 등 예상치 못한 예외 → 토큰 유지
       debugPrint('[Auth] reissue 예외 (${e.runtimeType}: $e) → 토큰 유지');
       return handler.next(err);
     }

--- a/lawding_flutter/lib/data/user/user_profile_response.dart
+++ b/lawding_flutter/lib/data/user/user_profile_response.dart
@@ -22,12 +22,12 @@ class UserProfileResponse {
   factory UserProfileResponse.fromJson(Map<String, dynamic> json) {
     return UserProfileResponse(
       id: json['id'] as int,
-      username: json['username'] as String,
-      email: json['email'] as String,
-      provider: json['provider'] as String,
-      nickname: json['nickname'] as String,
-      onboardingCompleted: json['onboardingCompleted'] as bool,
-      deleted: json['deleted'] as bool,
+      username: json['username'] as String? ?? '',
+      email: json['email'] as String? ?? '',
+      provider: json['provider'] as String? ?? '',
+      nickname: json['nickname'] as String? ?? '',
+      onboardingCompleted: json['onboardingCompleted'] as bool? ?? false,
+      deleted: json['deleted'] as bool? ?? false,
     );
   }
 

--- a/lawding_flutter/lib/domain/entities/calendar_event_request.dart
+++ b/lawding_flutter/lib/domain/entities/calendar_event_request.dart
@@ -1,33 +1,32 @@
 /// 캘린더 이벤트 생성/수정 요청 모델
 class CalendarEventRequest {
-  final String? title;           // 옵셔널
-  final String? description;     // 옵셔널
-  final DateTime startDatetime;  // 필수
-  final DateTime endDatetime;    // 필수
-  final int? usedLeaveMinutes;   // 옵셔널
-  final bool isAllDay;           // 필수
-  final bool isLeaveEvent;       // 필수
+  final String title;
+  final String description;
+  final DateTime startDatetime;
+  final DateTime endDatetime;
+  final int usedLeaveMinutes;
+  final bool isAllDay;
+  final bool isLeaveEvent;
 
   const CalendarEventRequest({
-    this.title,
-    this.description,
+    this.title = '',
+    this.description = '',
     required this.startDatetime,
     required this.endDatetime,
-    this.usedLeaveMinutes,
+    this.usedLeaveMinutes = 0,
     required this.isAllDay,
     required this.isLeaveEvent,
   });
 
   Map<String, dynamic> toJson() {
-    final map = <String, dynamic>{
+    return {
+      'title': title,
+      'description': description,
       'startDatetime': startDatetime.toIso8601String().split('.').first,
       'endDatetime': endDatetime.toIso8601String().split('.').first,
+      'usedLeaveMinutes': usedLeaveMinutes,
       'isAllDay': isAllDay,
       'isLeaveEvent': isLeaveEvent,
     };
-    if (title != null) map['title'] = title;
-    if (description != null) map['description'] = description;
-    if (usedLeaveMinutes != null) map['usedLeaveMinutes'] = usedLeaveMinutes;
-    return map;
   }
 }

--- a/lawding_flutter/lib/domain/repositories/calendar_event_repository.dart
+++ b/lawding_flutter/lib/domain/repositories/calendar_event_repository.dart
@@ -25,7 +25,7 @@ abstract interface class CalendarEventRepository {
 
   /// 캘린더 이벤트 수정
   /// PUT /v1/calendar-events/{id}
-  Future<Result<CalendarEventEntity, NetworkError>> updateCalendarEvent({
+  Future<Result<void, NetworkError>> updateCalendarEvent({
     required int id,
     required CalendarEventRequest request,
   });

--- a/lawding_flutter/lib/domain/usecases/update_calendar_event_usecase.dart
+++ b/lawding_flutter/lib/domain/usecases/update_calendar_event_usecase.dart
@@ -1,5 +1,4 @@
 import '../core/result.dart';
-import '../entities/calendar_event.dart';
 import '../repositories/calendar_event_repository.dart';
 import '../entities/calendar_event_request.dart';
 import '../../data/network/network_error.dart';
@@ -10,7 +9,7 @@ class UpdateCalendarEventUseCase {
 
   UpdateCalendarEventUseCase(this._repository);
 
-  Future<Result<CalendarEventEntity, NetworkError>> execute({
+  Future<Result<void, NetworkError>> execute({
     required int id,
     required CalendarEventRequest request,
   }) {

--- a/lawding_flutter/lib/presentation/providers/providers.dart
+++ b/lawding_flutter/lib/presentation/providers/providers.dart
@@ -281,6 +281,10 @@ GetLeavePolicyUseCase getLeavePolicyUseCase(Ref ref) {
 /// 로그인 후 fetch된 LeavePolicy에서 계산. 미조회 시 기본값 480(8시간)
 final dailyWorkMinutesProvider = StateProvider<int>((ref) => 480);
 
+/// avgDailyWorkHoursProvider — 하루 평균 근무시간(시간 단위)
+/// 로그인/정보변경 후 fetch된 LeaveSummary의 avgDailyWorkHours. 미조회 시 기본값 8.0
+final avgDailyWorkHoursProvider = StateProvider<double>((ref) => 8.0);
+
 /// GetUserProfileUseCase Provider
 /// 유저 프로필 조회 비즈니스 로직 제공
 @riverpod

--- a/lawding_flutter/lib/presentation/screens/basic_info/steps/step3_work_schedule.dart
+++ b/lawding_flutter/lib/presentation/screens/basic_info/steps/step3_work_schedule.dart
@@ -96,12 +96,14 @@ class _Step3WorkScheduleState extends State<Step3WorkSchedule>
           breakEnds[day] = _getTime(day: day, isStart: false, isWork: false);
         }
       }
-      widget.onDataChanged?.call(Step3Data(
-        workStarts: starts,
-        workEnds: ends,
-        breakStarts: breakStarts,
-        breakEnds: breakEnds,
-      ));
+      widget.onDataChanged?.call(
+        Step3Data(
+          workStarts: starts,
+          workEnds: ends,
+          breakStarts: breakStarts,
+          breakEnds: breakEnds,
+        ),
+      );
     }
   }
 
@@ -168,15 +170,84 @@ class _Step3WorkScheduleState extends State<Step3WorkSchedule>
     _notify();
   }
 
+  /// 상대방 시간이 이미 설정되어 있는지 여부 (per-day 모드에서 미설정이면 검사 스킵)
+  bool _isCounterpartSet({
+    required int day,
+    required bool isStart,
+    required bool isWork,
+  }) {
+    if (isWork) {
+      if (_unifyWorkTime) return true;
+      return isStart
+          ? _perWorkEnd.containsKey(day)
+          : _perWorkStart.containsKey(day);
+    } else {
+      if (_daysWithoutBreak.contains(day)) return false;
+      if (_unifyBreakTime) return true;
+      return isStart
+          ? _perBreakEnd.containsKey(day)
+          : _perBreakStart.containsKey(day);
+    }
+  }
+
+  void _showTimeError(String message) {
+    showCupertinoDialog<void>(
+      context: context,
+      builder: (ctx) => CupertinoAlertDialog(
+        title: const Text('시간 설정 오류'),
+        content: Text(message),
+        actions: [
+          CupertinoDialogAction(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('확인'),
+          ),
+        ],
+      ),
+    );
+  }
+
   Future<void> _onTimeTap({
     required int day,
     required bool isStart,
     required bool isWork,
   }) async {
+    TimeOfDay? minTime;
+    TimeOfDay? maxTime;
+
+    if (_isCounterpartSet(day: day, isStart: isStart, isWork: isWork)) {
+      final counterpart = _getTime(day: day, isStart: !isStart, isWork: isWork);
+      if (isStart) {
+        maxTime = counterpart; // 시작 시간 < 마감 시간
+      } else {
+        minTime = counterpart; // 마감 시간 > 시작 시간
+      }
+    }
+
     final picked = await _showTimePicker(
       _getTime(day: day, isStart: isStart, isWork: isWork),
+      minTime: minTime,
+      maxTime: maxTime,
     );
     if (picked == null || !mounted) return;
+
+    // 혹시라도 통과된 경우 최종 방어
+    if (minTime != null) {
+      final pickedMin = picked.hour * 60 + picked.minute;
+      final minMin = minTime.hour * 60 + minTime.minute;
+      if (pickedMin <= minMin) {
+        _showTimeError('마감 시간은 시작 시간보다 늦은 시간이어야 합니다.');
+        return;
+      }
+    }
+    if (maxTime != null) {
+      final pickedMin = picked.hour * 60 + picked.minute;
+      final maxMin = maxTime.hour * 60 + maxTime.minute;
+      if (pickedMin >= maxMin) {
+        _showTimeError('시작 시간은 마감 시간보다 이른 시간이어야 합니다.');
+        return;
+      }
+    }
+
     setState(() {
       final unified = isWork ? _unifyWorkTime : _unifyBreakTime;
       if (unified) {
@@ -212,9 +283,23 @@ class _Step3WorkScheduleState extends State<Step3WorkSchedule>
     _notify();
   }
 
-  Future<TimeOfDay?> _showTimePicker(TimeOfDay initial) async {
-    var tempHour = initial.hour;
-    var tempMinute = (initial.minute / 5).round() * 5 % 60;
+  Future<TimeOfDay?> _showTimePicker(
+    TimeOfDay initial, {
+    TimeOfDay? minTime,
+    TimeOfDay? maxTime,
+  }) async {
+    // 초기값을 범위 안으로 클램핑
+    int clampedTotalMin = initial.hour * 60 + initial.minute;
+    if (minTime != null) {
+      final minMin = minTime.hour * 60 + minTime.minute + 5;
+      if (clampedTotalMin <= minMin - 5) clampedTotalMin = minMin;
+    }
+    if (maxTime != null) {
+      final maxMin = maxTime.hour * 60 + maxTime.minute - 5;
+      if (clampedTotalMin >= maxMin + 5) clampedTotalMin = maxMin;
+    }
+    var tempHour = clampedTotalMin ~/ 60;
+    var tempMinute = (clampedTotalMin % 60 ~/ 5) * 5;
 
     return showModalBottomSheet<TimeOfDay>(
       context: context,
@@ -303,8 +388,10 @@ class _Step3WorkScheduleState extends State<Step3WorkSchedule>
   }
 
   static String _formatTime(TimeOfDay t) {
-    final prefix = t.hour < 12 ? '오전' : '오후';
-    return '$prefix ${t.hour.toString().padLeft(2, '0')} : ${t.minute.toString().padLeft(2, '0')}';
+    final isAm = t.hour < 12;
+    final prefix = isAm ? '오전' : '오후';
+    final hour = t.hour == 0 ? 12 : (t.hour > 12 ? t.hour - 12 : t.hour);
+    return '$prefix ${hour.toString().padLeft(2, '0')} : ${t.minute.toString().padLeft(2, '0')}';
   }
 
   @override

--- a/lawding_flutter/lib/presentation/screens/basic_info/steps/step6_used_leave.dart
+++ b/lawding_flutter/lib/presentation/screens/basic_info/steps/step6_used_leave.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -25,12 +26,16 @@ class _Step6UsedLeaveState extends State<Step6UsedLeave>
   bool get wantKeepAlive => true;
 
   final _controller = TextEditingController();
+  final _focusNode = FocusNode();
 
   double? get _usedDays => double.tryParse(_controller.text);
 
   bool get _isValid {
     final u = _usedDays;
-    return u != null && u >= 0;
+    if (u == null || u < 0) return false;
+    final total = widget.totalDays;
+    if (total != null && u > total) return false;
+    return true;
   }
 
   double? get _remainingDays {
@@ -40,16 +45,49 @@ class _Step6UsedLeaveState extends State<Step6UsedLeave>
     return total - used;
   }
 
-  void _notify() {
-    setState(() {});
-    widget.onValidChanged(_isValid);
-    if (_isValid) widget.onDataChanged?.call(_usedDays!);
+  @override
+  void initState() {
+    super.initState();
+    _focusNode.addListener(_onFocusLost);
   }
 
   @override
   void dispose() {
+    _focusNode.removeListener(_onFocusLost);
+    _focusNode.dispose();
     _controller.dispose();
     super.dispose();
+  }
+
+  void _onFocusLost() {
+    if (_focusNode.hasFocus) return;
+    if (!mounted) return;
+    if (ModalRoute.of(context)?.isCurrent != true) return;
+    final total = widget.totalDays;
+    final used = _usedDays;
+    if (total == null || used == null || used <= total) return;
+    showCupertinoDialog<void>(
+      context: context,
+      builder: (ctx) => CupertinoAlertDialog(
+        title: const Text('입력 오류'),
+        content: Text(
+          '사용한 연차가 총 발생 연차(${_fmt(total)})를 초과할 수 없습니다',
+        ),
+        actions: [
+          CupertinoDialogAction(
+            isDestructiveAction: true,
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('확인'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _notify() {
+    setState(() {});
+    widget.onValidChanged(_isValid);
+    if (_isValid) widget.onDataChanged?.call(_usedDays!);
   }
 
   static String _fmt(double? days) {
@@ -135,6 +173,7 @@ class _Step6UsedLeaveState extends State<Step6UsedLeave>
             child: Center(
               child: TextField(
                 controller: _controller,
+                focusNode: _focusNode,
                 keyboardType: const TextInputType.numberWithOptions(
                   decimal: true,
                 ),

--- a/lawding_flutter/lib/presentation/screens/calendar/add_calendar_event_screen.dart
+++ b/lawding_flutter/lib/presentation/screens/calendar/add_calendar_event_screen.dart
@@ -255,6 +255,25 @@ class _AddCalendarEventScreenState
     return _leavePolicy!.workPattern[_weekdayNames[d.weekday]!] == null;
   }
 
+  /// 근로일인데 입력 시간이 근무 시간과 전혀 겹치지 않는 날이 하나라도 있는지 확인
+  bool _hasWorkDayWithNoOverlap(List<DateTime> dates) {
+    if (_startTime == null || _endTime == null) return false;
+    final policy = _leavePolicy;
+    if (policy == null) return false;
+    final inputStart = _startTime!.hour * 60 + _startTime!.minute;
+    final inputEnd = _endTime!.hour * 60 + _endTime!.minute;
+    return dates.any((d) {
+      if (_isHolidayDate(d)) return false;
+      final workSlot = policy.workPattern[_weekdayNames[d.weekday]!];
+      if (workSlot == null) return false;
+      final workStart = _parseTimeStr(workSlot.start);
+      final workEnd = _parseTimeStr(workSlot.end);
+      final effStart = inputStart > workStart ? inputStart : workStart;
+      final effEnd = inputEnd < workEnd ? inputEnd : workEnd;
+      return effStart >= effEnd; // 교집합 없음
+    });
+  }
+
   /// 입력 시간이 근무 시간 외(시작 전 또는 종료 후)에 걸치는 근로일이 하나라도 있는지 확인
   bool _hasOutsideWorkHours(List<DateTime> dates) {
     if (_startTime == null || _endTime == null) return false;
@@ -459,6 +478,25 @@ class _AddCalendarEventScreenState
           builder: (ctx) => CupertinoAlertDialog(
             title: const Text('연차 사용 불가'),
             content: const Text('근무일이 아닌 경우 연차 사용이 불가합니다'),
+            actions: [
+              CupertinoDialogAction(
+                isDestructiveAction: true,
+                onPressed: () => Navigator.pop(ctx),
+                child: const Text('닫기'),
+              ),
+            ],
+          ),
+        );
+        return;
+      }
+
+      // 근로일이지만 입력 시간이 근무시간과 전혀 겹치지 않는 경우 → 제출 차단
+      if (!_isAllDay && _hasWorkDayWithNoOverlap(dates)) {
+        await showCupertinoDialog<void>(
+          context: context,
+          builder: (ctx) => CupertinoAlertDialog(
+            title: const Text('입력 오류'),
+            content: const Text('연차를 사용할 근로시간을 확인해주세요'),
             actions: [
               CupertinoDialogAction(
                 isDestructiveAction: true,

--- a/lawding_flutter/lib/presentation/screens/calendar/add_calendar_event_screen.dart
+++ b/lawding_flutter/lib/presentation/screens/calendar/add_calendar_event_screen.dart
@@ -2,15 +2,20 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../domain/entities/calendar_event.dart';
 import '../../../domain/entities/calendar_event_request.dart';
 import '../../../data/network/network_error.dart';
 import '../../../domain/core/result.dart';
 import '../../../domain/entities/holiday.dart';
+import '../../../domain/entities/leave_policy.dart';
 import '../../core/design_system.dart';
 import '../../providers/providers.dart';
 
 class AddCalendarEventScreen extends ConsumerStatefulWidget {
-  const AddCalendarEventScreen({super.key});
+  /// null이면 등록 모드, non-null이면 수정 모드
+  final CalendarEventEntity? editEvent;
+
+  const AddCalendarEventScreen({super.key, this.editEvent});
 
   @override
   ConsumerState<AddCalendarEventScreen> createState() =>
@@ -32,6 +37,8 @@ class _AddCalendarEventScreenState
   late List<List<DateTime>> _weeks;
   TimeOfDay? _startTime;
   TimeOfDay? _endTime;
+  double _avgDailyWorkHours = 8.0;
+  LeavePolicy? _leavePolicy;
 
   final _titleController = TextEditingController();
   final _descriptionController = TextEditingController();
@@ -40,10 +47,33 @@ class _AddCalendarEventScreenState
   @override
   void initState() {
     super.initState();
-    final now = DateTime.now();
-    _calendarMonth = DateTime(now.year, now.month, 1);
+    final edit = widget.editEvent;
+    if (edit != null) {
+      _isLeaveEvent = edit.isLeaveEvent;
+      _isAllDay = edit.isAllDay;
+      _startDate = edit.startDatetime;
+      _endDate = _isSameDay(edit.startDatetime, edit.endDatetime)
+          ? null
+          : edit.endDatetime;
+      if (!edit.isAllDay) {
+        _startTime = TimeOfDay.fromDateTime(edit.startDatetime);
+        _endTime = TimeOfDay.fromDateTime(edit.endDatetime);
+      }
+      _titleController.text = edit.title;
+      _descriptionController.text = edit.description;
+      _calendarMonth = DateTime(
+        edit.startDatetime.year,
+        edit.startDatetime.month,
+        1,
+      );
+    } else {
+      final now = DateTime.now();
+      _calendarMonth = DateTime(now.year, now.month, 1);
+    }
     _weeks = _buildWeeks(_calendarMonth);
     _fetchHolidays();
+    _fetchLeaveSummary();
+    _fetchLeavePolicy();
   }
 
   @override
@@ -53,12 +83,33 @@ class _AddCalendarEventScreenState
     super.dispose();
   }
 
+  Future<void> _fetchLeaveSummary() async {
+    final result = await ref.read(getLeaveSummaryUseCaseProvider).execute();
+    switch (result) {
+      case Success(:final value):
+        if (!mounted) return;
+        setState(() => _avgDailyWorkHours = value.avgDailyWorkHours);
+      case Failure():
+        break;
+    }
+  }
+
+  Future<void> _fetchLeavePolicy() async {
+    final result = await ref.read(getLeavePolicyUseCaseProvider).execute();
+    switch (result) {
+      case Success(:final value):
+        if (!mounted) return;
+        setState(() => _leavePolicy = value);
+      case Failure():
+        break;
+    }
+  }
+
   Future<void> _fetchHolidays() async {
     final year = _calendarMonth.year;
-    final result = await ref.read(getHolidaysUseCaseProvider).execute(
-      startYear: year - 1,
-      endYear: year + 2,
-    );
+    final result = await ref
+        .read(getHolidaysUseCaseProvider)
+        .execute(startYear: year - 1, endYear: year + 2);
     switch (result) {
       case Success(:final value):
         if (!mounted) return;
@@ -121,28 +172,113 @@ class _AddCalendarEventScreenState
     return '${isAm ? '오전' : '오후'} $h시$m분';
   }
 
-  String _calcUsedTime() {
-    if (_startTime == null || _endTime == null) return '00시간00분';
-    final s = _startTime!.hour * 60 + _startTime!.minute;
-    final e = _endTime!.hour * 60 + _endTime!.minute;
-    final diff = (e - s).clamp(0, 24 * 60);
-    final h = diff ~/ 60;
-    final m = diff % 60;
-    return '${h.toString().padLeft(2, '0')}시간${m.toString().padLeft(2, '0')}분';
-  }
-
   String _formatMinutes(int minutes) {
     final h = minutes ~/ 60;
     final m = minutes % 60;
     return '${h.toString().padLeft(2, '0')}시간${m.toString().padLeft(2, '0')}분';
   }
 
-  int _calcUsedMinutes() {
-    if (_isAllDay) return ref.read(dailyWorkMinutesProvider);
+  static const _weekdayNames = {
+    1: 'MONDAY',
+    2: 'TUESDAY',
+    3: 'WEDNESDAY',
+    4: 'THURSDAY',
+    5: 'FRIDAY',
+    6: 'SATURDAY',
+    7: 'SUNDAY',
+  };
+
+  static int _parseTimeStr(String t) {
+    final p = t.split(':');
+    return int.parse(p[0]) * 60 + int.parse(p[1]);
+  }
+
+  /// 해당 날짜에 실제 차감될 연차 시간(분) — 공휴일·비근로일·비근무시간 제외, 하루 최대 avgDailyWorkHours
+  int _calcUsedMinutesForDate(DateTime date) {
+    if (_isHolidayDate(date)) return 0;
+
+    final maxMin = (_avgDailyWorkHours * 60).round();
+    final policy = _leavePolicy;
+
+    // 근무 정책이 있으면 비근로일 여부를 먼저 확인
+    if (policy != null) {
+      final dayName = _weekdayNames[date.weekday]!;
+      final workSlot = policy.workPattern[dayName];
+      if (workSlot == null) return 0; // 비근로일 (예: 월~금 근무자의 토·일)
+
+      if (_isAllDay) return maxMin;
+      if (_startTime == null || _endTime == null) return 0;
+
+      final workStart = _parseTimeStr(workSlot.start);
+      final workEnd = _parseTimeStr(workSlot.end);
+      final inputStart = _startTime!.hour * 60 + _startTime!.minute;
+      final inputEnd = _endTime!.hour * 60 + _endTime!.minute;
+
+      final effStart = inputStart > workStart ? inputStart : workStart;
+      final effEnd = inputEnd < workEnd ? inputEnd : workEnd;
+      if (effStart >= effEnd) return 0;
+
+      int breakDed = 0;
+      final breakSlot = policy.breakTimePattern[dayName];
+      if (breakSlot != null) {
+        final bStart = _parseTimeStr(breakSlot.start);
+        final bEnd = _parseTimeStr(breakSlot.end);
+        final oStart = effStart > bStart ? effStart : bStart;
+        final oEnd = effEnd < bEnd ? effEnd : bEnd;
+        if (oEnd > oStart) breakDed = oEnd - oStart;
+      }
+
+      return (effEnd - effStart - breakDed).clamp(0, maxMin);
+    }
+
+    // 정책 미로드 시 fallback
+    if (_isAllDay) return maxMin;
     if (_startTime == null || _endTime == null) return 0;
     final s = _startTime!.hour * 60 + _startTime!.minute;
     final e = _endTime!.hour * 60 + _endTime!.minute;
-    return (e - s).clamp(0, 24 * 60);
+    return (e - s).clamp(0, maxMin);
+  }
+
+  /// 선택된 전체 날짜의 합산 차감 시간(분)
+  int _calcTotalUsedMinutes() {
+    if (_startDate == null) return _calcUsedMinutes();
+    return _selectedDates().fold(
+      0,
+      (sum, d) => sum + _calcUsedMinutesForDate(d),
+    );
+  }
+
+  /// 날짜가 공휴일 또는 비근로일인지 확인
+  bool _isNonWorkOrHoliday(DateTime d) {
+    if (_isHolidayDate(d)) return true;
+    if (_leavePolicy == null) return false;
+    return _leavePolicy!.workPattern[_weekdayNames[d.weekday]!] == null;
+  }
+
+  /// 입력 시간이 근무 시간 외(시작 전 또는 종료 후)에 걸치는 근로일이 하나라도 있는지 확인
+  bool _hasOutsideWorkHours(List<DateTime> dates) {
+    if (_startTime == null || _endTime == null) return false;
+    final policy = _leavePolicy;
+    if (policy == null) return false;
+    final inputStart = _startTime!.hour * 60 + _startTime!.minute;
+    final inputEnd = _endTime!.hour * 60 + _endTime!.minute;
+    return dates.any((d) {
+      if (_isHolidayDate(d)) return false;
+      final workSlot = policy.workPattern[_weekdayNames[d.weekday]!];
+      if (workSlot == null) return false;
+      final workStart = _parseTimeStr(workSlot.start);
+      final workEnd = _parseTimeStr(workSlot.end);
+      return inputStart < workStart || inputEnd > workEnd;
+    });
+  }
+
+  int _calcUsedMinutes() {
+    if (_isAllDay) return (_avgDailyWorkHours * 60).round();
+    if (_startTime == null || _endTime == null) return 0;
+    if (_startDate != null) return _calcUsedMinutesForDate(_startDate!);
+    final s = _startTime!.hour * 60 + _startTime!.minute;
+    final e = _endTime!.hour * 60 + _endTime!.minute;
+    return (e - s).clamp(0, (_avgDailyWorkHours * 60).round());
   }
 
   Future<TimeOfDay?> _showTimePicker(TimeOfDay? initial) async {
@@ -239,24 +375,30 @@ class _AddCalendarEventScreenState
 
   /// 날짜별 API 요청 객체 생성
   List<CalendarEventRequest> _buildRequests(List<DateTime> dates) {
-    final title = _titleController.text.isEmpty ? null : _titleController.text;
-    final description = _descriptionController.text.isEmpty
-        ? null
-        : _descriptionController.text;
-    final usedLeaveMinutes = _isLeaveEvent ? _calcUsedMinutes() : null;
+    final title = _titleController.text;
+    final description = _descriptionController.text;
 
     return dates.map((date) {
+      final usedLeaveMinutes = _isLeaveEvent
+          ? _calcUsedMinutesForDate(date)
+          : 0;
       final startDt = _isAllDay
           ? DateTime(date.year, date.month, date.day, 0, 0)
           : DateTime(
-              date.year, date.month, date.day,
-              _startTime?.hour ?? 0, _startTime?.minute ?? 0,
+              date.year,
+              date.month,
+              date.day,
+              _startTime?.hour ?? 0,
+              _startTime?.minute ?? 0,
             );
       final endDt = _isAllDay
           ? DateTime(date.year, date.month, date.day, 23, 59)
           : DateTime(
-              date.year, date.month, date.day,
-              _endTime?.hour ?? 0, _endTime?.minute ?? 0,
+              date.year,
+              date.month,
+              date.day,
+              _endTime?.hour ?? 0,
+              _endTime?.minute ?? 0,
             );
       return CalendarEventRequest(
         title: title,
@@ -306,29 +448,107 @@ class _AddCalendarEventScreenState
       return;
     }
 
+    // ── 연차 사용 사전 검증 ──────────────────────────────────────────────────
+    if (_isLeaveEvent) {
+      final dates = _selectedDates();
+
+      // Condition 1: 선택 기간이 모두 비근로일/공휴일 → 제출 차단
+      if (dates.every(_isNonWorkOrHoliday)) {
+        await showCupertinoDialog<void>(
+          context: context,
+          builder: (ctx) => CupertinoAlertDialog(
+            title: const Text('연차 사용 불가'),
+            content: const Text('근무일이 아닌 경우 연차 사용이 불가합니다'),
+            actions: [
+              CupertinoDialogAction(
+                isDestructiveAction: true,
+                onPressed: () => Navigator.pop(ctx),
+                child: const Text('닫기'),
+              ),
+            ],
+          ),
+        );
+        return;
+      }
+
+      // Condition 2: 이틀 이상 기간에 비근로일/공휴일이 하나라도 포함 → 안내 후 제출
+      if (dates.length >= 2 && dates.any(_isNonWorkOrHoliday)) {
+        final ok = await showCupertinoDialog<bool>(
+          context: context,
+          builder: (ctx) => CupertinoAlertDialog(
+            content: const Text('비근로일/공휴일은 자동으로 연차 사용에서 제외됩니다'),
+            actions: [
+              CupertinoDialogAction(
+                onPressed: () => Navigator.pop(ctx, true),
+                child: const Text('확인'),
+              ),
+            ],
+          ),
+        );
+        if (ok != true || !mounted) return;
+      }
+
+      // Condition 3: 종일 아닌 경우 입력 시간이 근무시간 외 영역에 걸침 → 안내 후 제출
+      if (!_isAllDay && _hasOutsideWorkHours(dates)) {
+        final ok = await showCupertinoDialog<bool>(
+          context: context,
+          builder: (ctx) => CupertinoAlertDialog(
+            content: const Text('비근무시간은 자동으로 연차 사용에서 제외됩니다'),
+            actions: [
+              CupertinoDialogAction(
+                onPressed: () => Navigator.pop(ctx, true),
+                child: const Text('확인'),
+              ),
+            ],
+          ),
+        );
+        if (ok != true || !mounted) return;
+      }
+    }
+
     setState(() => _isSubmitting = true);
 
-    final requests = _buildRequests(_selectedDates());
-    final useCase = ref.read(createCalendarEventUseCaseProvider);
-    final results = await Future.wait(
-      requests.map((r) => useCase.execute(request: r)),
-    );
+    final editId = widget.editEvent?.id;
+    NetworkError? error;
+
+    if (editId != null) {
+      // 수정 모드: 단건 PUT
+      final request = _buildRequests([_startDate!]).first;
+      final result = await ref
+          .read(updateCalendarEventUseCaseProvider)
+          .execute(id: editId, request: request);
+      if (result is Failure) {
+        error = (result as Failure<void, NetworkError>).error;
+      }
+    } else {
+      // 등록 모드: 날짜별 POST
+      final requests = _buildRequests(_selectedDates());
+      final results = await Future.wait(
+        requests.map(
+          (r) =>
+              ref.read(createCalendarEventUseCaseProvider).execute(request: r),
+        ),
+      );
+      error = results
+          .whereType<Failure<void, NetworkError>>()
+          .firstOrNull
+          ?.error;
+    }
 
     if (!mounted) return;
     setState(() => _isSubmitting = false);
 
-    final failure = results.whereType<Failure<void, NetworkError>>().firstOrNull;
-    if (failure == null) {
+    if (error == null) {
       Navigator.pop(context);
       return;
     }
 
-    final message = switch (failure.error) {
+    final message = switch (error) {
       ServerError(:final message) => message,
       TimeoutError() => '요청 시간이 초과되었습니다.',
       UnauthorizedError() => '로그인이 필요합니다.',
       NetworkConnectionError() => '네트워크 연결을 확인해주세요.',
-      _ => '일정 등록에 실패했습니다.',
+      _ => '일정 ${editId != null ? '수정' : '등록'}에 실패했습니다.',
     };
     _showErrorDialog(message);
   }
@@ -362,6 +582,10 @@ class _AddCalendarEventScreenState
                     _buildMemoCard(),
                     const SizedBox(height: 26),
                     _buildSubmitButton(),
+                    if (widget.editEvent != null) ...[
+                      const SizedBox(height: 12),
+                      _buildDeleteButton(),
+                    ],
                     const SizedBox(height: 40),
                   ],
                 ),
@@ -415,7 +639,7 @@ class _AddCalendarEventScreenState
           // 제목 — 남은 공간 가운데
           Expanded(
             child: Text(
-              '일정 등록',
+              widget.editEvent != null ? '일정 수정' : '일정 등록',
               textAlign: TextAlign.center,
               style: pretendard(
                 weight: 700,
@@ -901,9 +1125,7 @@ class _AddCalendarEventScreenState
               ),
               const Spacer(),
               Text(
-                _isAllDay
-                    ? _formatMinutes(ref.read(dailyWorkMinutesProvider))
-                    : _calcUsedTime(),
+                _formatMinutes(_calcTotalUsedMinutes()),
                 style: pretendard(
                   weight: 700,
                   size: 14,
@@ -1014,6 +1236,63 @@ class _AddCalendarEventScreenState
         ),
       ),
     );
+  }
+
+  // ── 삭제하기 (수정 모드 전용) ─────────────────────────────────────────────
+
+  Widget _buildDeleteButton() {
+    return SizedBox(
+      width: double.infinity,
+      height: 48,
+      child: ElevatedButton(
+        onPressed: _isSubmitting ? null : _confirmDelete,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: const Color(0xFFFF5252),
+          foregroundColor: Colors.white,
+          disabledBackgroundColor: const Color(
+            0xFFFF5252,
+          ).withValues(alpha: 0.5),
+          elevation: 0,
+          shadowColor: Colors.transparent,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10),
+          ),
+        ),
+        child: Text(
+          '삭제하기',
+          style: pretendard(weight: 700, size: 15, color: Colors.white),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _confirmDelete() async {
+    final id = widget.editEvent?.id;
+    if (id == null) return;
+    final confirmed = await showCupertinoDialog<bool>(
+      context: context,
+      builder: (ctx) => CupertinoAlertDialog(
+        title: const Text('일정 삭제'),
+        content: const Text('이 일정을 삭제하시겠습니까?'),
+        actions: [
+          CupertinoDialogAction(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('취소'),
+          ),
+          CupertinoDialogAction(
+            isDestructiveAction: true,
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('삭제'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    final result = await ref
+        .read(deleteCalendarEventUseCaseProvider)
+        .execute(id: id);
+    if (!mounted) return;
+    if (result case Success()) Navigator.pop(context);
   }
 
   // ── 등록하기 ──────────────────────────────────────────────────────────────

--- a/lawding_flutter/lib/presentation/screens/calendar/calendar_screen.dart
+++ b/lawding_flutter/lib/presentation/screens/calendar/calendar_screen.dart
@@ -32,12 +32,14 @@ enum CalendarEventType {
 }
 
 class CalendarEvent {
+  final int? id; // 공휴일은 null
   final DateTime date;
   final CalendarEventType type;
   final String label; // 셀 배지: 공휴일명 또는 "HH:MM-HH:MM" 또는 "종일"
   final String name; // 카드 제목 (비공휴일), 미입력 시 label 표시
   final String detail; // 카드 하단 메모 (isFocused 확장 카드)
   const CalendarEvent({
+    this.id,
     required this.date,
     required this.type,
     required this.label,
@@ -89,12 +91,7 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
     super.dispose();
   }
 
-  /// 소수점 3자리, 불필요한 trailing zero 제거 (예: 1.000 → 1, 1.500 → 1.5)
-  String _formatDays(double days) {
-    final s = days.toStringAsFixed(3);
-    final trimmed = s.replaceAll(RegExp(r'\.?0+$'), '');
-    return trimmed;
-  }
+  String _formatDays(double days) => days.toStringAsFixed(3);
 
   Future<void> _fetchLeaveSummary() async {
     final useCase = ref.read(getLeaveSummaryUseCaseProvider);
@@ -117,10 +114,9 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
 
   Future<void> _fetchHolidays() async {
     final currentYear = _today.year;
-    final result = await ref.read(getHolidaysUseCaseProvider).execute(
-      startYear: currentYear - 1,
-      endYear: currentYear + 2,
-    );
+    final result = await ref
+        .read(getHolidaysUseCaseProvider)
+        .execute(startYear: currentYear - 1, endYear: currentYear + 2);
     switch (result) {
       case Success(:final value):
         debugPrint(
@@ -169,6 +165,7 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
     }
 
     return CalendarEvent(
+      id: entity.id,
       date: entity.startDatetime,
       type: type,
       label: label,
@@ -350,30 +347,32 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
       ),
       child: Stack(
         children: [
-          // 닉네임 (top: 91-81=10, left: 37-20=17)
+          // 닉네임 + 남은 연차 라벨 (5px 간격, baseline 정렬)
           Positioned(
             top: 10,
             left: 17,
-            child: Text(
-              '${data?.nickname ?? ''}님',
-              style: pretendard(
-                weight: 700,
-                size: 20,
-                color: AppColors.brandColor,
-              ),
-            ),
-          ),
-          // 남은 연차 라벨 (top: 96-81=15, left: 163-20=143)
-          Positioned(
-            top: 15,
-            left: 143,
-            child: Text(
-              '남은 연차',
-              style: pretendard(
-                weight: 700,
-                size: 13,
-                color: AppColors.brandColor,
-              ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.baseline,
+              textBaseline: TextBaseline.alphabetic,
+              children: [
+                Text(
+                  '${data?.nickname ?? ''}님',
+                  style: pretendard(
+                    weight: 700,
+                    size: 20,
+                    color: AppColors.brandColor,
+                  ),
+                ),
+                const SizedBox(width: 5),
+                Text(
+                  '남은 연차',
+                  style: pretendard(
+                    weight: 700,
+                    size: 13,
+                    color: AppColors.brandColor,
+                  ),
+                ),
+              ],
             ),
           ),
           // 회색 pill (top: 120-81=39, left: 30-20=10)
@@ -389,32 +388,36 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
               ),
             ),
           ),
-          // 남은 일수 (top: 125-81=44, left: 42-20=22)
+          // 남은 일수 + 남은 시간 (baseline 정렬로 bottom 맞춤)
           Positioned(
             top: 44,
             left: 22,
-            child: Text(
-              data == null ? '' : '${_formatDays(data.availableLeaveDays)}일',
-              style: pretendard(
-                weight: 700,
-                size: 20,
-                color: AppColors.textGray11,
-              ),
-            ),
-          ),
-          // 남은 시간 (top: 129-81=48, left: 132-20=112)
-          Positioned(
-            top: 48,
-            left: 112,
-            child: Text(
-              data == null
-                  ? ''
-                  : '${data.availableLeaveHours.toStringAsFixed(2)}시간',
-              style: pretendard(
-                weight: 700,
-                size: 13,
-                color: AppColors.textGray55,
-              ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.baseline,
+              textBaseline: TextBaseline.alphabetic,
+              children: [
+                Text(
+                  data == null
+                      ? ''
+                      : '${_formatDays(data.availableLeaveDays)}일',
+                  style: pretendard(
+                    weight: 700,
+                    size: 20,
+                    color: AppColors.textGray11,
+                  ),
+                ),
+                const SizedBox(width: 5),
+                Text(
+                  data == null
+                      ? ''
+                      : '${data.availableLeaveHours.toStringAsFixed(2)}시간',
+                  style: pretendard(
+                    weight: 700,
+                    size: 13,
+                    color: AppColors.textGray55,
+                  ),
+                ),
+              ],
             ),
           ),
           // 시간 편집 아이콘 (top: 130-81=49, left: 192-20=172)
@@ -452,6 +455,7 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                       _displayedMonth.year,
                       _displayedMonth.month,
                     );
+                    _fetchLeaveSummary();
                   }
                 },
                 child: SvgPicture.asset(
@@ -970,6 +974,91 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
   }
 
   /// isFocused=true: 내용에 따라 높이가 변하는 확장 카드
+  Future<void> _showEventOptions(CalendarEvent event) async {
+    await showCupertinoModalPopup<void>(
+      context: context,
+      builder: (ctx) => CupertinoActionSheet(
+        actions: [
+          CupertinoActionSheetAction(
+            onPressed: () {
+              Navigator.pop(ctx);
+              final entity = CalendarEventEntity(
+                id: event.id!,
+                title: event.name,
+                description: event.detail,
+                startDatetime: event.date,
+                endDatetime: event.date,
+                usedLeaveMinutes: 0,
+                isAllDay: event.label == '종일',
+                isLeaveEvent: event.type == CalendarEventType.annualLeave,
+              );
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => AddCalendarEventScreen(editEvent: entity),
+                ),
+              ).then((_) {
+                if (mounted) {
+                  _fetchCalendarEvents(
+                    _displayedMonth.year,
+                    _displayedMonth.month,
+                  );
+                  _fetchLeaveSummary();
+                }
+              });
+            },
+            child: const Text('수정하기'),
+          ),
+          CupertinoActionSheetAction(
+            isDestructiveAction: true,
+            onPressed: () {
+              Navigator.pop(ctx);
+              showCupertinoDialog<void>(
+                context: context,
+                builder: (dialogCtx) => CupertinoAlertDialog(
+                  title: const Text('일정 삭제'),
+                  content: const Text('이 일정을 삭제하시겠습니까?'),
+                  actions: [
+                    CupertinoDialogAction(
+                      onPressed: () => Navigator.pop(dialogCtx),
+                      child: const Text('취소'),
+                    ),
+                    CupertinoDialogAction(
+                      isDestructiveAction: true,
+                      onPressed: () {
+                        Navigator.pop(dialogCtx);
+                        _deleteEvent(event);
+                      },
+                      child: const Text('삭제'),
+                    ),
+                  ],
+                ),
+              );
+            },
+            child: const Text('삭제하기'),
+          ),
+        ],
+        cancelButton: CupertinoActionSheetAction(
+          onPressed: () => Navigator.pop(ctx),
+          child: const Text('취소'),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _deleteEvent(CalendarEvent event) async {
+    final id = event.id;
+    if (id == null) return;
+    final result = await ref
+        .read(deleteCalendarEventUseCaseProvider)
+        .execute(id: id);
+    if (!mounted) return;
+    if (result case Success()) {
+      _fetchCalendarEvents(_displayedMonth.year, _displayedMonth.month);
+      _fetchLeaveSummary();
+    }
+  }
+
   Widget _buildExpandedEventCard(CalendarEvent event) {
     final isHoliday = event.type == CalendarEventType.holiday;
     final hasDetail = event.detail.isNotEmpty;
@@ -1038,21 +1127,29 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.end,
               children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: List.generate(
-                    3,
-                    (i) => Container(
-                      width: 4,
-                      height: 4,
-                      margin: EdgeInsets.only(left: i == 0 ? 0 : 3),
-                      decoration: const BoxDecoration(
-                        color: AppColors.textGray99,
-                        shape: BoxShape.circle,
+                if (!isHoliday)
+                  GestureDetector(
+                    onTap: () => _showEventOptions(event),
+                    behavior: HitTestBehavior.opaque,
+                    child: Padding(
+                      padding: const EdgeInsets.all(4),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: List.generate(
+                          3,
+                          (i) => Container(
+                            width: 4,
+                            height: 4,
+                            margin: EdgeInsets.only(left: i == 0 ? 0 : 3),
+                            decoration: const BoxDecoration(
+                              color: AppColors.textGray99,
+                              shape: BoxShape.circle,
+                            ),
+                          ),
+                        ),
                       ),
                     ),
                   ),
-                ),
                 if (event.type == CalendarEventType.annualLeave) ...[
                   const Spacer(),
                   _buildAnnualLeaveBadge(event.label),

--- a/lawding_flutter/lib/presentation/screens/calendar/calendar_tutorial_screen.dart
+++ b/lawding_flutter/lib/presentation/screens/calendar/calendar_tutorial_screen.dart
@@ -214,16 +214,20 @@ class _CalendarTutorialScreenState extends State<CalendarTutorialScreen>
                 child: Padding(
                   padding: const EdgeInsets.only(bottom: 40),
                   child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      // 이전 버튼
-                      _NavButton(
-                        label: '이전',
-                        enabled: _currentPage > 0,
-                        onTap: _goToPrevious,
+                      // 이전 버튼 — 오른쪽 버튼과 동일 너비 확보
+                      Expanded(
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: _NavButton(
+                            label: '이전',
+                            enabled: _currentPage > 0,
+                            onTap: _goToPrevious,
+                          ),
+                        ),
                       ),
 
-                      // 페이지 인디케이터
+                      // 페이지 인디케이터 — 항상 정가운데 고정
                       Row(
                         children: List.generate(_pages.length, (index) {
                           final isActive = index == _currentPage;
@@ -242,13 +246,18 @@ class _CalendarTutorialScreenState extends State<CalendarTutorialScreen>
                         }),
                       ),
 
-                      // 다음 / 시작하기 버튼
-                      _NavButton(
-                        label: _currentPage == _pages.length - 1
-                            ? '시작하기'
-                            : '다음',
-                        enabled: true,
-                        onTap: _goToNext,
+                      // 다음 / 시작하기 버튼 — 왼쪽 버튼과 동일 너비 확보
+                      Expanded(
+                        child: Align(
+                          alignment: Alignment.centerRight,
+                          child: _NavButton(
+                            label: _currentPage == _pages.length - 1
+                                ? '시작하기'
+                                : '다음',
+                            enabled: true,
+                            onTap: _goToNext,
+                          ),
+                        ),
                       ),
                     ],
                   ),

--- a/lawding_flutter/lib/presentation/screens/dashboard/dashboard_screen.dart
+++ b/lawding_flutter/lib/presentation/screens/dashboard/dashboard_screen.dart
@@ -9,10 +9,10 @@ import '../../../domain/entities/leave_dashboard.dart';
 import '../../core/design_system.dart';
 import '../../providers/providers.dart';
 import '../../widgets/common/logo_app_bar.dart';
-import '../auth/login_screen.dart';
 
 class DashboardScreen extends ConsumerStatefulWidget {
-  const DashboardScreen({super.key});
+  final VoidCallback? onAuthRequired;
+  const DashboardScreen({super.key, this.onAuthRequired});
 
   @override
   ConsumerState<DashboardScreen> createState() => _DashboardScreenState();
@@ -59,6 +59,21 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
   @override
   Widget build(BuildContext context) {
     final isCalendarLinked = ref.watch(calendarAuthStateProvider);
+
+    ref.listen(calendarAuthStateProvider, (prev, next) {
+      if (prev == next) return;
+      if (next) {
+        // 로그인 완료 → 대시보드 재조회
+        setState(() => _isLoading = true);
+        _fetchDashboard();
+      } else {
+        // 로그아웃 → 데이터 초기화
+        setState(() {
+          _dashboard = null;
+          _isLoading = false;
+        });
+      }
+    });
 
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -540,13 +555,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
             child: BackdropFilter(
               filter: ui.ImageFilter.blur(sigmaX: 1.5, sigmaY: 1.5),
               child: GestureDetector(
-                onTap: () => Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => LoginScreen(
-                      onLoginSuccess: (_) => Navigator.of(context).pop(),
-                    ),
-                  ),
-                ),
+                onTap: () => widget.onAuthRequired?.call(),
                 child: Container(
                   color: const Color(0xB3000000),
                   alignment: Alignment.center,

--- a/lawding_flutter/lib/presentation/screens/setting/setting_screen.dart
+++ b/lawding_flutter/lib/presentation/screens/setting/setting_screen.dart
@@ -2,17 +2,18 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../domain/core/result.dart';
 import '../../core/design_system.dart';
 import '../../providers/providers.dart';
 import '../../widgets/common/custom_app_bar.dart';
 import '../../widgets/common/toast_message.dart';
 import '../basic_info/basic_info_screen.dart';
 
-class SettingScreen extends StatelessWidget {
+class SettingScreen extends ConsumerWidget {
   const SettingScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       backgroundColor: const Color(0xFFFBFBFB),
       appBar: const CustomAppBar(
@@ -31,7 +32,17 @@ class SettingScreen extends StatelessWidget {
                 MaterialPageRoute(
                   builder: (_) => BasicInfoScreen(
                     isEditMode: true,
-                    onCompleted: () => Navigator.of(context).pop(),
+                    onCompleted: () async {
+                      Navigator.of(context).pop();
+                      final result = await ref
+                          .read(getLeaveSummaryUseCaseProvider)
+                          .execute();
+                      if (result case Success(:final value)) {
+                        ref
+                            .read(avgDailyWorkHoursProvider.notifier)
+                            .state = value.avgDailyWorkHours;
+                      }
+                    },
                   ),
                 ),
               ),

--- a/lawding_flutter/lib/presentation/screens/splash/splash_screen.dart
+++ b/lawding_flutter/lib/presentation/screens/splash/splash_screen.dart
@@ -8,6 +8,7 @@ import '../../../domain/core/result.dart';
 import '../../../infrastructure/services/analytics_service.dart';
 import '../../../infrastructure/services/app_version_service.dart';
 import '../../../infrastructure/services/crashlytics_service.dart';
+import '../../core/design_system.dart';
 import '../../providers/providers.dart';
 import '../../widgets/force_update_dialog.dart';
 import '../auth/login_screen.dart';
@@ -70,12 +71,53 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
     }
   }
 
+  Future<void> _restoreAuthState() async {
+    final hasToken = await ref.read(authRepositoryProvider).isLoggedIn();
+    if (!hasToken) return;
+
+    final result = await ref.read(getUserProfileUseCaseProvider).execute();
+    result.fold(
+      onSuccess: (profile) {
+        if (profile.onboardingCompleted) {
+          ref.read(calendarAuthStateProvider.notifier).state = true;
+          _fetchLeavePolicy();
+          _fetchLeaveSummary();
+        }
+      },
+      onFailure: (_) {},
+    );
+  }
+
+  Future<void> _fetchLeavePolicy() async {
+    final result = await ref.read(getLeavePolicyUseCaseProvider).execute();
+    result.fold(
+      onSuccess: (policy) {
+        ref.read(dailyWorkMinutesProvider.notifier).state =
+            policy.dailyWorkMinutes;
+      },
+      onFailure: (_) {},
+    );
+  }
+
+  Future<void> _fetchLeaveSummary() async {
+    final result = await ref.read(getLeaveSummaryUseCaseProvider).execute();
+    result.fold(
+      onSuccess: (summary) {
+        ref.read(avgDailyWorkHoursProvider.notifier).state =
+            summary.avgDailyWorkHours;
+      },
+      onFailure: (_) {},
+    );
+  }
+
   Future<void> _initializeApp() async {
     try {
-      // 저장된 토큰 확인
+      // 저장된 토큰 확인 및 로그인 상태 복원
       final authRepo = ref.read(authRepositoryProvider);
       final accessToken = await authRepo.getAccessToken();
       debugPrint('[Splash] accessToken: $accessToken');
+
+      await _restoreAuthState();
 
       // 이전 세션에서 크래시가 발생했는지 확인
       final didCrash = await _crashlytics.didCrashOnPreviousExecution();
@@ -139,7 +181,10 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
             width: 24,
             height: 24,
           ),
-          screen: const DashboardScreen(),
+          screen: DashboardScreen(
+            onAuthRequired: () =>
+                _calendarScreenKey.currentState?.showTutorialIfNeeded(),
+          ),
         ),
         TabItemInfo(
           title: '연차 계산기',
@@ -286,17 +331,25 @@ class _CalendarTabScreenState extends ConsumerState<_CalendarTabScreen> {
         final prefs = await SharedPreferences.getInstance();
         await prefs.setBool(_tutorialKey, true);
         if (!mounted) return;
+        bool proceeded = false;
         await Navigator.of(context, rootNavigator: true).push(
           PageRouteBuilder(
             opaque: true,
             pageBuilder: (context, animation, secondaryAnimation) =>
-                CalendarTutorialScreen(onFinished: _showLoginScreen),
+                CalendarTutorialScreen(
+                  onFinished: () {
+                    proceeded = true;
+                    Navigator.of(context, rootNavigator: true).pop();
+                  },
+                ),
             transitionDuration: const Duration(milliseconds: 400),
             transitionsBuilder:
                 (context, animation, secondaryAnimation, child) =>
                     FadeTransition(opacity: animation, child: child),
           ),
         );
+        if (!mounted) return;
+        if (proceeded) _showLoginScreen();
       } else {
         _showLoginScreen();
       }
@@ -336,6 +389,17 @@ class _CalendarTabScreenState extends ConsumerState<_CalendarTabScreen> {
     );
   }
 
+  Future<void> _fetchLeaveSummary() async {
+    final result = await ref.read(getLeaveSummaryUseCaseProvider).execute();
+    result.fold(
+      onSuccess: (summary) {
+        ref.read(avgDailyWorkHoursProvider.notifier).state =
+            summary.avgDailyWorkHours;
+      },
+      onFailure: (error) => debugPrint('[LeaveSummary] 실패: $error'),
+    );
+  }
+
   Future<void> _fetchLeavePolicy() async {
     debugPrint('[LeavePolicy] GET /v1/users/leave-policy 호출');
     final result = await ref.read(getLeavePolicyUseCaseProvider).execute();
@@ -369,6 +433,7 @@ class _CalendarTabScreenState extends ConsumerState<_CalendarTabScreen> {
 
     if (onboardingCompleted) {
       _fetchLeavePolicy();
+      _fetchLeaveSummary();
       ref.read(calendarAuthStateProvider.notifier).state = true;
     } else {
       Navigator.of(context, rootNavigator: true).push(
@@ -391,6 +456,8 @@ class _CalendarTabScreenState extends ConsumerState<_CalendarTabScreen> {
 
   void _onUserInfoCompleted() {
     Navigator.of(context, rootNavigator: true).pop();
+    _fetchLeavePolicy();
+    _fetchLeaveSummary();
     ref.read(calendarAuthStateProvider.notifier).state = true;
   }
 
@@ -399,6 +466,43 @@ class _CalendarTabScreenState extends ConsumerState<_CalendarTabScreen> {
     final isLoggedIn = ref.watch(calendarAuthStateProvider);
     if (isLoggedIn) return const CalendarScreen();
     if (_isLoading) return const Center(child: CircularProgressIndicator());
-    return const SizedBox.shrink();
+    return _buildLoginPrompt();
+  }
+
+  Widget _buildLoginPrompt() {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            '로그인이 필요한 서비스입니다.',
+            style: pretendard(
+              weight: 600,
+              size: 16,
+              color: AppColors.textGray55,
+            ),
+          ),
+          const SizedBox(height: 20),
+          GestureDetector(
+            onTap: showTutorialIfNeeded,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 14),
+              decoration: BoxDecoration(
+                color: AppColors.brandColor,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                '로그인하기',
+                style: pretendard(
+                  weight: 700,
+                  size: 15,
+                  color: Colors.white,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lawding_flutter/pubspec.yaml
+++ b/lawding_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.4.0+17
+version: 1.4.0+18
 
 environment:
   sdk: ^3.10.1

--- a/lawding_flutter/pubspec.yaml
+++ b/lawding_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.4.0+18
+version: 1.4.0+19
 
 environment:
   sdk: ^3.10.1

--- a/lawding_flutter/test/data/auth/auth_interceptor_test.dart
+++ b/lawding_flutter/test/data/auth/auth_interceptor_test.dart
@@ -11,6 +11,7 @@ import '../../helpers/mock_dio_helper.dart';
 void main() {
   group('AuthInterceptor Tests', () {
     late MockDioHelper mockDioHelper;
+    late MockDioHelper reissueMockHelper; // reissue 전용 mock
     late AuthRepositoryImpl authRepository;
     // authDioClient — 로그인 필요 API용 (Bearer 토큰 주입 + 401 재시도)
     late DioClient authDioClient;
@@ -18,11 +19,13 @@ void main() {
     setUp(() {
       FlutterSecureStorage.setMockInitialValues({});
       mockDioHelper = MockDioHelper(baseUrl: 'https://api.test.com');
+      reissueMockHelper = MockDioHelper(baseUrl: 'https://api.test.com');
       authRepository = AuthRepositoryImpl();
       authDioClient = DioClient(
         baseUrl: 'https://api.test.com',
         authRepository: authRepository,
         dio: mockDioHelper.dio,
+        reissueDio: reissueMockHelper.dio,
       );
     });
 
@@ -150,6 +153,133 @@ void main() {
 
       // Then: 타임아웃은 토큰에 영향 없음
       expect(await authRepository.getAccessToken(), 'valid_access_token');
+    });
+
+    // ========================================================================
+    // 401 → reissue 성공 → 원본 요청 재시도
+    // ========================================================================
+
+    test('401 응답 시 reissue 성공하면 토큰 갱신 후 원본 요청 재시도', () async {
+      // Given: 만료된 accessToken + 유효한 refreshToken 저장
+      await authRepository.saveTokens(
+        accessToken: 'expired_access_token',
+        refreshToken: 'valid_refresh_token',
+      );
+
+      // Given: 원본 API 첫 요청 → 401
+      mockDioHelper.mockError(
+        path: '/v1/test',
+        method: 'GET',
+        statusCode: 401,
+        errorMessage: 'Unauthorized',
+      );
+      // Given: 재시도 요청 → 200
+      mockDioHelper.mockGet(
+        path: '/v1/test',
+        responseData: {'result': 'ok'},
+        statusCode: 200,
+      );
+
+      // Given: reissue → 새 토큰 발급
+      reissueMockHelper.mockPost(
+        path: '/v1/auth/reissue',
+        responseData: {
+          'data': {
+            'accessToken': 'new_access_token',
+            'refreshToken': 'new_refresh_token',
+          },
+        },
+        statusCode: 200,
+      );
+
+      // When
+      final response = await authDioClient.request(
+        const ApiRequest(path: '/v1/test', method: HttpMethod.get),
+      );
+
+      // Then: 재시도 성공
+      expect(response.statusCode, 200);
+      // Then: 새 토큰 저장 확인
+      expect(await authRepository.getAccessToken(), 'new_access_token');
+      expect(await authRepository.getRefreshToken(), 'new_refresh_token');
+    });
+
+    // ========================================================================
+    // 401 → reissue 실패 (401) → 토큰 삭제 → 로그아웃
+    // ========================================================================
+
+    test('401 응답 시 reissue도 401 반환하면 토큰 삭제', () async {
+      // Given: 만료된 토큰
+      await authRepository.saveTokens(
+        accessToken: 'expired_access_token',
+        refreshToken: 'expired_refresh_token',
+      );
+
+      // Given: 원본 API → 401
+      mockDioHelper.mockError(
+        path: '/v1/test',
+        method: 'GET',
+        statusCode: 401,
+        errorMessage: 'Unauthorized',
+      );
+
+      // Given: reissue → 401 (refreshToken도 만료)
+      reissueMockHelper.mockError(
+        path: '/v1/auth/reissue',
+        method: 'POST',
+        statusCode: 401,
+        errorMessage: 'Refresh token expired',
+      );
+
+      // When / Then: UnauthorizedError throw
+      await expectLater(
+        () => authDioClient.request(
+          const ApiRequest(path: '/v1/test', method: HttpMethod.get),
+        ),
+        throwsA(isA<UnauthorizedError>()),
+      );
+
+      // Then: 토큰 삭제됨
+      expect(await authRepository.getAccessToken(), isNull);
+      expect(await authRepository.getRefreshToken(), isNull);
+    });
+
+    // ========================================================================
+    // 401 → reissue 네트워크 오류 → 토큰 유지
+    // ========================================================================
+
+    test('401 응답 시 reissue 타임아웃이면 토큰 유지', () async {
+      // Given: 유효한 토큰
+      await authRepository.saveTokens(
+        accessToken: 'valid_access_token',
+        refreshToken: 'valid_refresh_token',
+      );
+
+      // Given: 원본 API → 401
+      mockDioHelper.mockError(
+        path: '/v1/test',
+        method: 'GET',
+        statusCode: 401,
+        errorMessage: 'Unauthorized',
+      );
+
+      // Given: reissue → 타임아웃
+      reissueMockHelper.mockTimeout(
+        path: '/v1/auth/reissue',
+        method: 'POST',
+      );
+
+      // When / Then: UnauthorizedError throw
+      await expectLater(
+        () => authDioClient.request(
+          const ApiRequest(path: '/v1/test', method: HttpMethod.get),
+        ),
+        throwsA(isA<UnauthorizedError>()),
+      );
+
+      // Then: 일시적 오류이므로 토큰 유지
+      expect(await authRepository.getAccessToken(), 'valid_access_token');
+      expect(await authRepository.getRefreshToken(), 'valid_refresh_token');
     });
   });
 }

--- a/lawding_flutter/test/data/calendar_event/create_calendar_event_repository_test.dart
+++ b/lawding_flutter/test/data/calendar_event/create_calendar_event_repository_test.dart
@@ -92,7 +92,7 @@ void main() {
       expect(result, isA<Success<void, NetworkError>>());
     });
 
-    test('생성 성공 - title/description 없이 최소 필드만', () async {
+    test('생성 성공 - title/description 빈 문자열, usedLeaveMinutes 0 (기본값)', () async {
       mockDioHelper.mockPost(
         path: _path,
         responseData: {'status': 'SUCCESS'},


### PR DESCRIPTION
## 이슈 번호: #75

## PR 타입

- [x] 기능 구현
- [x] 오류 수정
- [ ] 리팩토링

<br>

### 작업 내용

- [x] 캘린더 이벤트 수정/삭제 기능 구현
  - 이벤트 카드 `...` 버튼 → CupertinoActionSheet (수정하기 / 삭제하기)
  - 삭제 시 확인 다이얼로그 표시
  - `AddCalendarEventScreen` 수정 모드 진입 시 타이틀 "일정 수정", 하단 삭제 버튼 추가
- [x] 일정 등록/수정/삭제 후 상단 남은 연차 UI 즉시 갱신
- [x] `CalendarEventRequest` DTO 전 필드 non-nullable로 변경
- [x] `CalendarEventSingleApiResponse.data` nullable 처리 (POST/PUT 응답 대응)
- [x] `updateCalendarEvent` 반환 타입 `Result<CalendarEventEntity>` → `Result<void>`
- [x] Auth Interceptor reissue 무한루프 방지
  - reissue 전용 별도 Dio 인스턴스 분리
  - reissue 응답 파싱 flat/nested 구조 모두 대응
- [x] `UserProfileResponse.fromJson` nullable 필드 안전 파싱 (온보딩 미완료 유저 null crash 수정)
- [x] 로그인/온보딩 플로우 개선
  - 토큰 보유 시 소셜 로그인 화면 재표시 없이 BasicInfo 직행
  - 로그인 건너뛴 후 하얀 화면 → 로그인 유도 버튼 표시
  - 대시보드 딤 처리 탭 시 동일 플로우 적용
  - 로그인/로그아웃 시 대시보드 데이터 갱신
- [x] Step3 근무시간 설정 시간 순서 유효성 검사 및 12시간제 표시
- [x] Step6 사용 연차 총 발생 연차 초과 입력 시 제출 차단
- [x] `AddCalendarEventScreen` 입력 시간이 근무시간과 겹치지 않는 경우 제출 차단
- [x] 캘린더 튜토리얼 하단 페이지 인디케이터 중앙 정렬 수정
- [x] auth interceptor 테스트 추가 (reissue 성공 / 401 / 타임아웃)

<br>

### PR 체크리스트

- [x] PR 제목과 태그 (Feat, Refactor, Fix...etc) 와 작업 내용 확인
- [x] 코딩 컨벤션 확인
- [x] PR 관련 내용만 작성했는가 확인

<br>

### PR 유의 및 기타 사항

- 없음
