### PR TITLE
fix: Android 패키지명 수정

### DIFF
--- a/lawding_flutter/lib/infrastructure/services/app_version_service.dart
+++ b/lawding_flutter/lib/infrastructure/services/app_version_service.dart
@@ -32,7 +32,7 @@ class AppVersionService {
 
   // 앱 스토어 ID
   static const String _iosAppId = '6751892414';
-  static const String _androidPackageName = 'GGimiOwner.AnnualLeaveCalculator';
+  static const String _androidPackageName = 'com.lawding.annualleavecalculator';
 
   /// 앱 스토어로 이동
   /// 플랫폼에 맞는 스토어 URL을 자동으로 생성하여 이동


### PR DESCRIPTION
## 이슈 번호: #79 

## PR 타입

- [ ] 기능 구현
- [x] 오류 수정
- [ ] 리팩토링

<br>

### 작업 내용

> 구현 및 작업 내용을 작성합니다.

- [x] Android Play Store 연결용 패키지명 오기재 수정 (`GGimiOwner.AnnualLeaveCalculator` → `com.lawding.annualleavecalculator`)

<br>

### PR 체크리스트

- [x] PR 제목과 태그 (Feat, Refactor, Fix...etc) 와 작업 내용 확인
- [x] 코딩 컨벤션 확인
- [x] PR 관련 내용만 작성했는가 확인

<br>

### PR 유의 및 기타 사항

> PR 리뷰 시 주의 깊게 보거나 유의해야 할 점들과 기타 사항을 작성합니다.

- `AppVersionService._androidPackageName` 값이 잘못 기재되어 강제 업데이트 팝업의 Play Store 이동이 정상 동작하지 않던 문제 수정
